### PR TITLE
Add support for Reply-To email(s)

### DIFF
--- a/ses.go
+++ b/ses.go
@@ -19,6 +19,7 @@ type Email struct {
 	Subject string   // Subject text to send
 	Text    string   // Text is the text body representation
 	HTML    string   // HTMLBody is the HTML body representation
+	ReplyTo []string // Reply-To email(s)
 }
 
 // SendEmail message.
@@ -49,9 +50,10 @@ func (s *SES) SendEmail(email Email) error {
 	}
 
 	_, err := s.Service.SendEmail(&ses.SendEmailInput{
-		Source:      &email.From,
-		Destination: dest,
-		Message:     msg,
+		Source:           &email.From,
+		Destination:      dest,
+		Message:          msg,
+		ReplyToAddresses: aws.StringSlice(email.ReplyTo),
 	})
 
 	return err


### PR DESCRIPTION
When the `ReplyTo` field is `nil`, the AWS package does not set the Reply-To field in the actual email so the field is optional.

Is there a good way to indicate that the field is optional?
